### PR TITLE
Tell boolector to *only* try and use lingeling

### DIFF
--- a/pkg/smt/setup-boolector.sh
+++ b/pkg/smt/setup-boolector.sh
@@ -4,7 +4,7 @@ git clone https://github.com/zyedidia/boolector
 cd boolector
 ./contrib/setup-lingeling.sh
 ./contrib/setup-btor2tools.sh
-./configure.sh && cd build && make
+./configure.sh --only-lingeling && cd build && make
 
 cd ..
 


### PR DESCRIPTION
On my machine, boolector seemed to detect that I had minisat and tried to use that, except I don't actually have the static library (or at least not the version it wanted) so I got linker errors. This tells it to only try and use lingeling.